### PR TITLE
Parsing error if a property for sale with a earliest move-in date is searched

### DIFF
--- a/Bug Report for EditAd.md
+++ b/Bug Report for EditAd.md
@@ -1,7 +1,7 @@
 ## Bug report
 
 ### Short description
-It is possible to delete a picture if an ad even you click on "Cancel".
+It is possible to delete a picture of an ad even you click on "Cancel".
 
 ### Reproduction
 - Go to myRooms

--- a/Bug Report for EditAd.md
+++ b/Bug Report for EditAd.md
@@ -1,0 +1,20 @@
+## Bug report
+
+### Short description
+It is possible to delete a picture if an ad even you click on "Cancel".
+
+### Reproduction
+- Go to myRooms
+- Click on an ad
+- Click on "EditAd"
+- Delete a picture
+- Click on "Cancel"
+
+### Expected / Observed Behaviour
+If you delete a picture when editing an ad you expect that the picture is gone if you click on "Submit". 
+But if you click on "Cancel" the picture should still be there. But right now the picture is gone even if 
+you click on "Cancel".
+
+### Reason
+Picture gets deleted in the database immediately after the click on the "Delete" button and not after 
+submitting the change of the ad.

--- a/baseProject/src/test/java/ch/unibe/ese/team1/test/testData/ParserTest.java
+++ b/baseProject/src/test/java/ch/unibe/ese/team1/test/testData/ParserTest.java
@@ -1,15 +1,9 @@
+
 package ch.unibe.ese.team1.test.testData;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-
-import static org.junit.Assert.assertFalse;
 
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import ch.unibe.ese.team1.controller.pojos.forms.EditProfileForm;
 import ch.unibe.ese.team1.controller.pojos.forms.SearchForm;
 import ch.unibe.ese.team1.controller.service.AdService;
 
@@ -22,7 +16,9 @@ public class ParserTest {
 	public void testLatestMoveInDate() {
 		SearchForm searchForm = new SearchForm();
 		int[] offerType = {2};
+		String[] propertyType = {"Room", "Studio"};
 		
+		searchForm.setType(propertyType);
 		searchForm.setOfferType(offerType);
 		searchForm.setRadius(5);
 		searchForm.setPrice(5000000);

--- a/baseProject/src/test/java/ch/unibe/ese/team1/test/testData/ParserTest.java
+++ b/baseProject/src/test/java/ch/unibe/ese/team1/test/testData/ParserTest.java
@@ -1,0 +1,33 @@
+package ch.unibe.ese.team1.test.testData;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import ch.unibe.ese.team1.controller.pojos.forms.EditProfileForm;
+import ch.unibe.ese.team1.controller.pojos.forms.SearchForm;
+import ch.unibe.ese.team1.controller.service.AdService;
+
+public class ParserTest {
+	
+	@Autowired
+	private AdService adService;
+	
+	@Test(expected = NullPointerException.class)
+	public void testLatestMoveInDate() {
+		SearchForm searchForm = new SearchForm();
+		int[] offerType = {2};
+		
+		searchForm.setOfferType(offerType);
+		searchForm.setRadius(5);
+		searchForm.setPrice(5000000);
+		searchForm.setCity("3012 - Bern");
+		searchForm.setLatestMoveInDate("12-10-2014");
+		adService.queryResults(searchForm);
+	}
+}


### PR DESCRIPTION
You have a bug in your search form. If you want to search for a property "for sale" and set a "Earliest move-in date" you get a NullPointerException. Additional information see created JUnit test "ParserTest".